### PR TITLE
Break pixel merging (VGA linking) into a separate function

### DIFF
--- a/depthmapXcli/runmethods.cpp
+++ b/depthmapXcli/runmethods.cpp
@@ -56,11 +56,8 @@ namespace dm_runmethods
         PointMap& currentMap = mgraph->getDisplayedPointMap();
 
         vector<PixelRefPair> newLinks = depthmapX::getLinksFromMergeLines(cmdP.linkOptions().getMergeLines(), currentMap);
-        for (size_t i = 0; i < newLinks.size(); i++)
-        {
-            PixelRefPair link = newLinks[i];
-            currentMap.mergePixels(link.a,link.b);
-        }
+        depthmapX::mergePixelPairs(newLinks, currentMap);
+
         perfWriter.addData("Linking graph", t.getTimeInSeconds());
         DO_TIMED("Writing graph", mgraph->write(cmdP.getOuputFile().c_str(),METAGRAPH_VERSION, false);)
     }

--- a/depthmapXcli/runmethods.cpp
+++ b/depthmapXcli/runmethods.cpp
@@ -55,7 +55,7 @@ namespace dm_runmethods
         SimpleTimer t;
         PointMap& currentMap = mgraph->getDisplayedPointMap();
 
-        vector<PixelRefPair> newLinks = depthmapX::getLinksFromMergeLines(cmdP.linkOptions().getMergeLines(), currentMap);
+        vector<PixelRefPair> newLinks = depthmapX::pixelateMergeLines(cmdP.linkOptions().getMergeLines(), currentMap);
         depthmapX::mergePixelPairs(newLinks, currentMap);
 
         perfWriter.addData("Linking graph", t.getTimeInSeconds());

--- a/salaTest/salaTest.pro
+++ b/salaTest/salaTest.pro
@@ -7,7 +7,8 @@ INCLUDEPATH += ../ThirdParty/Catch
 
 SOURCES += main.cpp \
     testentityparsing.cpp \
-    testpointmap.cpp
+    testpointmap.cpp \
+    testlinkutils.cpp
 
 win32:Release:LIBS += -L../genlib/release -L../salalib/release
 win32:Debug:LIBS += -L../genlib/debug -L../salalib/debug

--- a/salaTest/testlinkutils.cpp
+++ b/salaTest/testlinkutils.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Test linking - fully filled grid (no geometry)", "")
     SECTION ("Successful: bottom-left to top-right")
     {
         mergeLines.push_back(Line(bottomLeft,topRight));
-        std::vector<PixelRefPair> links = depthmapX::getLinksFromMergeLines(mergeLines,pointMap);
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
         REQUIRE(links.size() == 1);
         REQUIRE(links[0].a.x == 0);
         REQUIRE(links[0].a.y == 0);
@@ -66,7 +66,7 @@ TEST_CASE("Test linking - fully filled grid (no geometry)", "")
         Point2f start(topRight.x, bottomLeft.y);
         Point2f end(bottomLeft.x, topRight.y);
         mergeLines.push_back(Line(start,end));
-        std::vector<PixelRefPair> links = depthmapX::getLinksFromMergeLines(mergeLines,pointMap);
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
         REQUIRE(links.size() == 2);
         REQUIRE(links[0].a.x == 0);
         REQUIRE(links[0].a.y == 0);
@@ -97,7 +97,8 @@ TEST_CASE("Test linking - fully filled grid (no geometry)", "")
     {
         Point2f start(bottomLeft.x - spacing, bottomLeft.y - spacing);
         mergeLines.push_back(Line(start,topRight));
-        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
+        REQUIRE_THROWS_WITH(depthmapX::mergePixelPairs(links, pointMap),
                             Catch::Contains("Line ends not both on painted analysis space"));
     }
 
@@ -105,7 +106,8 @@ TEST_CASE("Test linking - fully filled grid (no geometry)", "")
     {
         Point2f end(topRight.x + spacing, topRight.y + spacing);
         mergeLines.push_back(Line(bottomLeft,end));
-        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
+        REQUIRE_THROWS_WITH(depthmapX::mergePixelPairs(links, pointMap),
                             Catch::Contains("Line ends not both on painted analysis space"));
     }
 
@@ -115,7 +117,8 @@ TEST_CASE("Test linking - fully filled grid (no geometry)", "")
         Point2f start(bottomLeft.x, bottomLeft.y);
         Point2f end(topRight.x - 1, topRight.y);
         mergeLines.push_back(Line(start,end));
-        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
+        REQUIRE_THROWS_WITH(depthmapX::mergePixelPairs(links, pointMap),
                             Catch::Contains("Overlapping link found"));
     }
 
@@ -125,7 +128,8 @@ TEST_CASE("Test linking - fully filled grid (no geometry)", "")
         Point2f start(bottomLeft.x + 1, bottomLeft.y);
         Point2f end(topRight.x, topRight.y);
         mergeLines.push_back(Line(start,end));
-        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
+        REQUIRE_THROWS_WITH(depthmapX::mergePixelPairs(links, pointMap),
                             Catch::Contains("Overlapping link found"));
     }
 
@@ -133,14 +137,15 @@ TEST_CASE("Test linking - fully filled grid (no geometry)", "")
     {
         mergeLines.push_back(Line(bottomLeft,topRight));
         mergeLines.push_back(Line(bottomLeft,topRight));
-        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
+        REQUIRE_THROWS_WITH(depthmapX::mergePixelPairs(links, pointMap),
                             Catch::Contains("Overlapping link found"));
     }
 
     SECTION("Failing: link overlapping to previously merged")
     {
         mergeLines.push_back(Line(bottomLeft,topRight));
-        std::vector<PixelRefPair> links = depthmapX::getLinksFromMergeLines(mergeLines,pointMap);
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
         REQUIRE(links.size() == 1);
         REQUIRE(links[0].a.x == 0);
         REQUIRE(links[0].a.y == 0);
@@ -200,7 +205,7 @@ TEST_CASE("Test linking - half filled grid", "")
         Point2f start(bottomLeft.x, topRight.y);
         Point2f end(bottomLeft.x + spacing, topRight.y);
         mergeLines.push_back(Line(start,end));
-        std::vector<PixelRefPair> links = depthmapX::getLinksFromMergeLines(mergeLines,pointMap);
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
         REQUIRE(links.size() == 1);
         REQUIRE(links[0].a.x == 0);
         REQUIRE(links[0].a.y == 8);
@@ -224,7 +229,8 @@ TEST_CASE("Test linking - half filled grid", "")
         Point2f start(topRight.x, bottomLeft.y);
         Point2f end(topRight.x - 1, bottomLeft.y);
         mergeLines.push_back(Line(start,end));
-        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
+        REQUIRE_THROWS_WITH(depthmapX::mergePixelPairs(links, pointMap),
                             Catch::Contains("Line ends not both on painted analysis space"));
     }
 
@@ -233,7 +239,8 @@ TEST_CASE("Test linking - half filled grid", "")
         Point2f start(topRight.x, bottomLeft.y);
         Point2f end(bottomLeft.x, topRight.y);
         mergeLines.push_back(Line(start,end));
-        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
+        REQUIRE_THROWS_WITH(depthmapX::mergePixelPairs(links, pointMap),
                             Catch::Contains("Line ends not both on painted analysis space"));
     }
 
@@ -242,7 +249,8 @@ TEST_CASE("Test linking - half filled grid", "")
         Point2f start(bottomLeft.x, topRight.y);
         Point2f end(topRight.x, bottomLeft.y);
         mergeLines.push_back(Line(start,end));
-        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+        std::vector<PixelRefPair> links = depthmapX::pixelateMergeLines(mergeLines,pointMap);
+        REQUIRE_THROWS_WITH(depthmapX::mergePixelPairs(links, pointMap),
                             Catch::Contains("Line ends not both on painted analysis space"));
     }
 }

--- a/salaTest/testlinkutils.cpp
+++ b/salaTest/testlinkutils.cpp
@@ -1,0 +1,192 @@
+// Copyright (C) 2017 Petros Koutsolampros
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "catch.hpp"
+#include "salalib/mgraph.h"
+#include "salalib/linkutils.h"
+
+
+TEST_CASE("Test getLinksFromMergeLines - fully filled grid (no geometry)", "")
+{
+    double spacing = 0.5;
+    Point2f offset(0,0); // seems that this is always set to 0,0
+    Point2f bottomLeft(0,0);
+    Point2f topRight(2,4);
+    int fill_type = 0; // = QDepthmapView::FULLFILL
+
+    std::unique_ptr<SuperSpacePixel> spacePixel(new SuperSpacePixel("Test SuperSpacePixel"));
+    spacePixel->m_region = QtRegion(bottomLeft, topRight);
+    PointMap pointMap("Test PointMap");
+    pointMap.setSpacePixel(spacePixel.get());
+    pointMap.setGrid(spacing, offset);
+    Point2f gridBottomLeft = pointMap.getRegion().bottom_left;
+    Point2f midPoint(gridBottomLeft.x + spacing * (floor(pointMap.getCols() * 0.5) + 0.5),
+                         gridBottomLeft.y + spacing * (floor(pointMap.getRows() * 0.5) + 0.5));
+    pointMap.makePoints(midPoint, fill_type);
+
+    {
+        // successful: bottom-left to top-right
+        std::vector<Line> mergeLines;
+        mergeLines.push_back(Line(bottomLeft,topRight));
+        std::vector<PixelRefPair> links = depthmapX::getLinksFromMergeLines(mergeLines,pointMap);
+        REQUIRE(links.size() == 1);
+        REQUIRE(links[0].a.x == 0);
+        REQUIRE(links[0].a.y == 0);
+        REQUIRE(links[0].b.x == 4);
+        REQUIRE(links[0].b.y == 8);
+    }
+
+    {
+        // successfull: bottom-left to top-right and bottom-right to top-left
+        std::vector<Line> mergeLines;
+        mergeLines.push_back(Line(bottomLeft,topRight));
+        Point2f start(topRight.x, bottomLeft.y);
+        Point2f end(bottomLeft.x, topRight.y);
+        mergeLines.push_back(Line(start,end));
+        std::vector<PixelRefPair> links = depthmapX::getLinksFromMergeLines(mergeLines,pointMap);
+        REQUIRE(links.size() == 2);
+        REQUIRE(links[0].a.x == 0);
+        REQUIRE(links[0].a.y == 0);
+        REQUIRE(links[0].b.x == 4);
+        REQUIRE(links[0].b.y == 8);
+        REQUIRE(links[1].a.x == 0);
+        REQUIRE(links[1].a.y == 8);
+        REQUIRE(links[1].b.x == 4);
+        REQUIRE(links[1].b.y == 0);
+    }
+
+    {
+        // failing: merge line start out of grid
+        std::vector<Line> mergeLines;
+        Point2f start(bottomLeft.x - spacing, bottomLeft.y - spacing);
+        mergeLines.push_back(Line(start,topRight));
+        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+                            Catch::Contains("Line ends not both on painted analysis space"));
+    }
+
+    {
+        // failing: merge line end out of grid
+        std::vector<Line> mergeLines;
+        Point2f end(topRight.x + spacing, topRight.y + spacing);
+        mergeLines.push_back(Line(bottomLeft,end));
+        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+                            Catch::Contains("Line ends not both on painted analysis space"));
+    }
+
+    {
+        // failing: second link start overlapping
+        std::vector<Line> mergeLines;
+        mergeLines.push_back(Line(bottomLeft,topRight));
+        Point2f start(bottomLeft.x, bottomLeft.y);
+        Point2f end(topRight.x - 1, topRight.y);
+        mergeLines.push_back(Line(start,end));
+        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+                            Catch::Contains("Overlapping link found"));
+    }
+
+    {
+        // failing: second link end overlapping
+        std::vector<Line> mergeLines;
+        mergeLines.push_back(Line(bottomLeft,topRight));
+        Point2f start(bottomLeft.x + 1, bottomLeft.y);
+        Point2f end(topRight.x, topRight.y);
+        mergeLines.push_back(Line(start,end));
+        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+                            Catch::Contains("Overlapping link found"));
+    }
+
+    {
+        // failing: fully overlapping link (bottom-left to top-right)
+        std::vector<Line> mergeLines;
+        mergeLines.push_back(Line(bottomLeft,topRight));
+        mergeLines.push_back(Line(bottomLeft,topRight));
+        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+                            Catch::Contains("Overlapping link found"));
+    }
+}
+
+TEST_CASE("Test getLinksFromMergeLines - half filled grid", "")
+{
+
+    double spacing = 0.5;
+    Point2f offset(0,0); // seems that this is always set to 0,0
+    int fill_type = 0; // = QDepthmapView::FULLFILL
+
+    Point2f lineStart(0,0);
+    Point2f lineEnd(2,4);
+
+    Point2f bottomLeft(min(lineStart.x,lineEnd.x),min(lineStart.y,lineEnd.y));
+    Point2f topRight(max(lineStart.x,lineEnd.x),max(lineStart.y,lineEnd.y));
+
+    std::unique_ptr<SuperSpacePixel> spacePixel(new SuperSpacePixel("Test SuperSpacePixel"));
+    spacePixel->push_back(SpacePixelFile("Test SpacePixelGroup"));
+    spacePixel->tail().push_back(ShapeMap("Test ShapeMap"));
+    spacePixel->tail().tail().makeLineShape(Line(lineStart, lineEnd));
+    spacePixel->tail().m_region = spacePixel->tail().tail().getRegion();
+    spacePixel->m_region = spacePixel->tail().m_region;
+
+    PointMap pointMap("Test PointMap");
+    pointMap.setSpacePixel(spacePixel.get());
+    pointMap.setGrid(spacing, offset);
+
+    Point2f gridBottomLeft = pointMap.getRegion().bottom_left;
+    Point2f gridTopRight = pointMap.getRegion().top_right;
+    Point2f topLeftFillPoint(gridBottomLeft.x+spacing, gridTopRight.y-spacing);
+    pointMap.makePoints(topLeftFillPoint, fill_type);
+
+    {
+        // successful: top-left pixel to one to its right
+        std::vector<Line> mergeLines;
+        Point2f start(bottomLeft.x, topRight.y);
+        Point2f end(bottomLeft.x + spacing, topRight.y);
+        mergeLines.push_back(Line(start,end));
+        std::vector<PixelRefPair> links = depthmapX::getLinksFromMergeLines(mergeLines,pointMap);
+        REQUIRE(links.size() == 1);
+        REQUIRE(links[0].a.x == 0);
+        REQUIRE(links[0].a.y == 8);
+        REQUIRE(links[0].b.x == 1);
+        REQUIRE(links[0].b.y == 8);
+    }
+
+    {
+        // failing: merge line (bottom-right to the one its left) completely out of grid
+        std::vector<Line> mergeLines;
+        Point2f start(topRight.x, bottomLeft.y);
+        Point2f end(topRight.x - 1, bottomLeft.y);
+        mergeLines.push_back(Line(start,end));
+        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+                            Catch::Contains("Line ends not both on painted analysis space"));
+    }
+
+    {
+        // failing: merge line (bottom-right to top-left) start out of grid
+        std::vector<Line> mergeLines;
+        Point2f start(topRight.x, bottomLeft.y);
+        Point2f end(bottomLeft.x, topRight.y);
+        mergeLines.push_back(Line(start,end));
+        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+                            Catch::Contains("Line ends not both on painted analysis space"));
+    }
+
+    {
+        // failing: merge line (top-left to bottom-right) end out of grid
+        std::vector<Line> mergeLines;
+        Point2f start(bottomLeft.x, topRight.y);
+        Point2f end(topRight.x, bottomLeft.y);
+        mergeLines.push_back(Line(start,end));
+        REQUIRE_THROWS_WITH(depthmapX::getLinksFromMergeLines(mergeLines,pointMap),
+                            Catch::Contains("Line ends not both on painted analysis space"));
+    }
+}

--- a/salalib/linkutils.cpp
+++ b/salalib/linkutils.cpp
@@ -72,4 +72,29 @@ namespace depthmapX {
         }
         return mergePixelPairs;
     }
+
+    void mergePixelPairs(std::vector<PixelRefPair>& links, PointMap& currentMap) {
+
+        // check if any link pixel already exists on the map
+        for (size_t i = 0; i < links.size(); i++)
+        {
+            PixelRefPair link = links[i];
+            if(currentMap.isPixelMerged(link.a)
+                    || currentMap.isPixelMerged(link.b))
+            {
+                // one of the cells is already on the map
+                std::stringstream message;
+                message << "Link pixel found that is already linked on the map "
+                        << "(line " << i << ")"
+                        << flush;
+                throw depthmapX::RuntimeException(message.str().c_str());
+            }
+        }
+
+        for (size_t i = 0; i < links.size(); i++)
+        {
+            PixelRefPair link = links[i];
+            currentMap.mergePixels(link.a,link.b);
+        }
+    }
 }

--- a/salalib/linkutils.cpp
+++ b/salalib/linkutils.cpp
@@ -24,8 +24,8 @@ namespace depthmapX {
         for (size_t i = 0; i < mergeLines.size(); i++)
         {
             const Line & mergeLine = mergeLines[i];
-            const PixelRef & a = currentMap.pixelate(mergeLine.start());
-            const PixelRef & b = currentMap.pixelate(mergeLine.end());
+            const PixelRef & a = currentMap.pixelate(mergeLine.start(), false);
+            const PixelRef & b = currentMap.pixelate(mergeLine.end(), false);
 
             // check in limits:
             if (!currentMap.includes(a) || !currentMap.getPoint(a).filled()

--- a/salalib/linkutils.cpp
+++ b/salalib/linkutils.cpp
@@ -21,9 +21,12 @@ namespace depthmapX {
     std::vector<PixelRefPair> getLinksFromMergeLines(const std::vector<Line>& mergeLines, PointMap& currentMap)
     {
         vector<PixelRefPair> mergePixelPairs;
-        for (size_t i = 0; i < mergeLines.size(); i++)
+
+        std::vector<Line>::const_iterator iter = mergeLines.begin(), end =
+        mergeLines.end();
+        for ( ; iter != end; ++iter )
         {
-            const Line & mergeLine = mergeLines[i];
+            const Line & mergeLine = *iter;
             const PixelRef & a = currentMap.pixelate(mergeLine.start(), false);
             const PixelRef & b = currentMap.pixelate(mergeLine.end(), false);
 
@@ -33,7 +36,6 @@ namespace depthmapX {
             {
                 std::stringstream message;
                 message << "Line ends not both on painted analysis space "
-                        << i << " ("
                         << mergeLine.start().x << ", "
                         << mergeLine.start().y << " -> "
                         << mergeLine.end().x << ", "
@@ -56,7 +58,6 @@ namespace depthmapX {
                     // one of the cells has already been seen.
                     std::stringstream message;
                     message << "Overlapping link found at line "
-                            << i << " ("
                             << mergeLine.start().x << ", "
                             << mergeLine.start().y << " -> "
                             << mergeLine.end().x << ", "
@@ -73,28 +74,25 @@ namespace depthmapX {
         return mergePixelPairs;
     }
 
-    void mergePixelPairs(std::vector<PixelRefPair>& links, PointMap& currentMap) {
+    void mergePixelPairs(const std::vector<PixelRefPair>& links, PointMap& currentMap) {
 
         // check if any link pixel already exists on the map
-        for (size_t i = 0; i < links.size(); i++)
+        std::vector<PixelRefPair>::const_iterator iter = links.begin(), end =
+        links.end();
+        for ( ; iter != end; ++iter )
         {
-            PixelRefPair link = links[i];
+            const PixelRefPair link = *iter;
             if(currentMap.isPixelMerged(link.a)
                     || currentMap.isPixelMerged(link.b))
             {
                 // one of the cells is already on the map
                 std::stringstream message;
                 message << "Link pixel found that is already linked on the map "
-                        << "(line " << i << ")"
                         << flush;
                 throw depthmapX::RuntimeException(message.str().c_str());
             }
         }
-
-        for (size_t i = 0; i < links.size(); i++)
-        {
-            PixelRefPair link = links[i];
-            currentMap.mergePixels(link.a,link.b);
-        }
+        std::for_each(links.begin(), links.end(),
+                      [&](const PixelRefPair &pair)->void{ currentMap.mergePixels(pair.a,pair.b); });
     }
 }

--- a/salalib/linkutils.h
+++ b/salalib/linkutils.h
@@ -20,5 +20,5 @@
 
 namespace depthmapX {
     std::vector<PixelRefPair> getLinksFromMergeLines(const std::vector<Line>& mergeLines, PointMap& currentMap);
-    void mergePixelPairs(std::vector<PixelRefPair>& links, PointMap& currentMap);
+    void mergePixelPairs(const std::vector<PixelRefPair> &links, PointMap& currentMap);
 }

--- a/salalib/linkutils.h
+++ b/salalib/linkutils.h
@@ -19,6 +19,6 @@
 #include <vector>
 
 namespace depthmapX {
-    std::vector<PixelRefPair> getLinksFromMergeLines(const std::vector<Line>& mergeLines, PointMap& currentMap);
+    std::vector<PixelRefPair> pixelateMergeLines(const std::vector<Line>& mergeLines, PointMap& currentMap);
     void mergePixelPairs(const std::vector<PixelRefPair> &links, PointMap& currentMap);
 }

--- a/salalib/linkutils.h
+++ b/salalib/linkutils.h
@@ -20,4 +20,5 @@
 
 namespace depthmapX {
     std::vector<PixelRefPair> getLinksFromMergeLines(const std::vector<Line>& mergeLines, PointMap& currentMap);
+    void mergePixelPairs(std::vector<PixelRefPair>& links, PointMap& currentMap);
 }

--- a/salalib/pointdata.cpp
+++ b/salalib/pointdata.cpp
@@ -3611,7 +3611,7 @@ void PointMap::mergeFromShapeMap(const ShapeMap& shapemap)
 
 bool PointMap::isPixelMerged(PixelRef a)
 {
-    return getPoint(a).m_merge.empty();
+    return !getPoint(a).m_merge.empty();
 }
 
 //////////////////////////////////////////////////////////////////////////////////

--- a/salalib/pointdata.cpp
+++ b/salalib/pointdata.cpp
@@ -3609,7 +3609,7 @@ void PointMap::mergeFromShapeMap(const ShapeMap& shapemap)
    }
 }
 
-bool PointMap::isPixelMerged(PixelRef a)
+bool PointMap::isPixelMerged(const PixelRef& a)
 {
     return !getPoint(a).m_merge.empty();
 }

--- a/salalib/pointdata.cpp
+++ b/salalib/pointdata.cpp
@@ -3609,6 +3609,11 @@ void PointMap::mergeFromShapeMap(const ShapeMap& shapemap)
    }
 }
 
+bool PointMap::isPixelMerged(PixelRef a)
+{
+    return getPoint(a).m_merge.empty();
+}
+
 //////////////////////////////////////////////////////////////////////////////////
 
 /*

--- a/salalib/pointdata.h
+++ b/salalib/pointdata.h
@@ -283,7 +283,7 @@ public:
    bool unmergePoints();
    bool mergePixels(PixelRef a, PixelRef b);
    void mergeFromShapeMap(const ShapeMap& shapemap);
-   bool isPixelMerged(PixelRef a);
+   bool isPixelMerged(const PixelRef &a);
    //
    void outputSummary(ostream& myout, char delimiter = '\t');
    void outputMif( ostream& miffile, ostream& midfile );

--- a/salalib/pointdata.h
+++ b/salalib/pointdata.h
@@ -283,6 +283,7 @@ public:
    bool unmergePoints();
    bool mergePixels(PixelRef a, PixelRef b);
    void mergeFromShapeMap(const ShapeMap& shapemap);
+   bool isPixelMerged(PixelRef a);
    //
    void outputSummary(ostream& myout, char delimiter = '\t');
    void outputMif( ostream& miffile, ostream& midfile );


### PR DESCRIPTION
Provides a function "mergePixelPairs" which merges multiple pixel pairs on a pointMap. This allows for checking if a new link pixel has already been merged without having to do this in the "getLinksFromMergeLines" function. Also unit tests provided for both "mergePixelPairs" and "getLinksFromMergeLines"