### PR TITLE
Allow for limiting the zoom out ratio

### DIFF
--- a/depthmapX/depthmapView.cpp
+++ b/depthmapX/depthmapView.cpp
@@ -1196,7 +1196,21 @@ void QDepthmapView::wheelEvent(QWheelEvent *e)
    newCentre.x = m_centre.x + m_unit * double(newCentre.x - m_physical_centre.width());
    newCentre.y = m_centre.y + m_unit * double(m_physical_centre.height() - newCentre.y);
 
-   ZoomTowards(zoomFactor, newCentre);
+    if(!IsAtZoomLimits(zoomFactor, 10)) {
+        ZoomTowards(zoomFactor, newCentre);
+    }
+}
+
+// provides a way to limit how much can we zoom out in relation to the window
+// and graph bounding box size to avoid problems when zooming out too far
+bool QDepthmapView::IsAtZoomLimits(double ratio, double maxZoomOutRatio) {
+
+    QtRegion bounds = pDoc->m_meta_graph->getBoundingBox();
+    double maxUnit = __max(bounds.width() / width(), bounds.height() / height());
+    if(ratio > 1) {
+        // for zoom out
+        return m_unit * ratio > maxZoomOutRatio * maxUnit;
+    }
 }
 
 void QDepthmapView::ZoomTowards(double ratio, const Point2f& point)

--- a/depthmapX/depthmapView.h
+++ b/depthmapX/depthmapView.h
@@ -178,6 +178,7 @@ private:
    void ResetHoverWnd(const QPoint& p = QPoint(-1,-1));
    void CreateHoverWnd();
 
+   bool IsAtZoomLimits(double ratio, double maxZoomOutRatio);
    void ZoomTowards(double ratio, const Point2f& point);
 
    void InitViewport(const QRect& phys_bounds, QGraphDoc *pDoc);


### PR DESCRIPTION
This is a semi-permanent fix to avoid fixing the problem of the application crashing (at least on macOS) when one zooms too far out. It also has the positive side-effect that it's harder to lose the plan by zooming out too far. The underlying problem (crash on zoom out) should be looked at when (and if) the display is switched from the current custom solution to a graphics library (i.e. OpenGL)